### PR TITLE
updated to v2.1 of CRIS api

### DIFF
--- a/samples/batch/csharp/batchclient.cs
+++ b/samples/batch/csharp/batchclient.cs
@@ -11,6 +11,7 @@ namespace BatchClient
     using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Net.Http.Formatting;
     using System.Net.Http.Headers;
     using System.Threading.Tasks;
 
@@ -27,7 +28,7 @@ namespace BatchClient
         private BatchClient(HttpClient client)
         {
             this.client = client;
-            speechToTextBasePath = "api/speechtotext/v2.0/";
+            speechToTextBasePath = "api/speechtotext/v2.1/";
         }
 
         public static async Task<BatchClient> CreateApiV1ClientAsync(string username, string key, string hostName, int port)
@@ -170,10 +171,10 @@ namespace BatchClient
         {
 
             string res = Newtonsoft.Json.JsonConvert.SerializeObject(payload);
+            StringContent sc = new StringContent(res);
+            sc.Headers.ContentType = JsonMediaTypeFormatter.DefaultMediaType;
 
-
-
-            using (var response = await this.client.PostAsJsonAsync(path, payload).ConfigureAwait(false))
+            using (var response = await client.PostAsync(path, sc))
             {
                 return await GetLocationFromPostResponseAsync(response).ConfigureAwait(false);
             }

--- a/samples/batch/csharp/transcription_definition.cs
+++ b/samples/batch/csharp/transcription_definition.cs
@@ -14,7 +14,7 @@ namespace BatchClient
         {
             this.Name = name;
             this.Description = description;
-            this.RecordingsUrl = recordingsUrl;
+            this.RecordingsUrls = new Uri[] { recordingsUrl };
             this.Locale = locale;
             this.Models = models;
             this.properties = new Dictionary<string, string>();
@@ -30,7 +30,7 @@ namespace BatchClient
         public string Description { get; set; }
 
         /// <inheritdoc />
-        public Uri RecordingsUrl { get; set; }
+        public Uri[] RecordingsUrls { get; set; }
 
         public string Locale { get; set; }
 
@@ -44,7 +44,7 @@ namespace BatchClient
             string locale,
             Uri recordingsUrl)
         {
-            return TranscriptionDefinition.Create(name, description, locale, recordingsUrl, null);
+            return TranscriptionDefinition.Create(name, description, locale, recordingsUrl, new ModelIdentity[0]);
         }
 
         public static TranscriptionDefinition Create(


### PR DESCRIPTION
## Purpose
The batch client is for 2.0 and does not work with v2.1 of the CRIS api. meaning if you have a webhook registered with v2.1 

## Pull Request Type

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:

